### PR TITLE
백준 5639 - 이진 검색 트리

### DIFF
--- a/BOJ/boj_5639.java
+++ b/BOJ/boj_5639.java
@@ -1,0 +1,88 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj_5639 {
+
+  private static Node root;
+  private static StringBuilder sb;
+
+  private static Node insert(final int number, Node node) {
+    if(node == null) {
+      return new Node(number);
+    }
+
+    if(node.number > number) {
+      Node retVal = insert(number, node.left);
+      if(retVal != null)
+        node.left = retVal;
+    }
+    else {
+      Node retVal = insert(number, node.right);
+      if(retVal != null)
+        node.right = retVal;
+    }
+
+    return null;
+  }
+
+  // left- right - root
+  private static void printPostorder(Node node) {
+    if(node.left != null)
+      printPostorder(node.left);
+    if(node.right != null)
+      printPostorder(node.right);
+    sb.append(node).append('\n');
+  }
+
+  /**
+   * 입력값을 정수로 반환한다.
+   * 반환값의 범위는 10^6보다 작은 양의 정수이다.
+   * @return EOF인 경우 0을 반환한다.
+   */
+  private static int read(BufferedReader br) throws IOException {
+    String input = br.readLine();
+    if(input == null)
+      return 0;
+    return Integer.parseInt(input);
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    int number = read(br);
+    if(number == 0)
+      return;
+    root = insert(number,root);
+
+    while (true) {
+      number = read(br);
+      if(number == 0)
+        break;
+      insert(number,root);
+    }
+
+    sb = new StringBuilder();
+    printPostorder(root);
+    sb.deleteCharAt(sb.length()-1);
+    System.out.println(sb);
+  }
+
+  private static class Node {
+    private int number;
+    private Node left, right;
+
+    public Node(int number) {
+      this.number = number;
+      this.left = null;
+      this.right = null;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(number);
+    }
+  }
+
+}


### PR DESCRIPTION
분류 : 구현, 트리
출처 : https://www.acmicpc.net/problem/5639

---
이진 트리 전위 -> 후위로 출력하는 문제였다. 
키의 값은 10^6이하, 노드의 수는 10,000개 이하로 주어졌다.

1. int[] 배열 10001개 선언 후 insert -> ArrayIndexOutOfBounds
  - 문제의 이진 트리는 편향 이진트리가 될 가능성이 있었기 때문에 배열방식으로 구현할 경우 문제 발생
2. Node 클래스 생성 후 왼쪽, 오른쪽 노드 객체를 가르키는 방식으로 구현

---
다른 풀이로는 입력이 루트 -> 왼쪽 -> 오른쪽인 점을 이용해 배열에 일렬로 입력 값을 저장하고 후위 표기식으로 출력하는 풀이가 있었다.