### PR TITLE
백준 9251 - LCS

### DIFF
--- a/BOJ/boj_9251.java
+++ b/BOJ/boj_9251.java
@@ -1,0 +1,37 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * [백준-9251] LCS
+ *  출처 : https://www.acmicpc.net/problem/9251
+ */
+
+public class boj_9251 {
+
+  public static void main(String[] args) throws IOException {
+
+    // input
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    char[] str1 = br.readLine().toCharArray();
+    char[] str2 = br.readLine().toCharArray();
+
+    int[][] lcs = new int[str2.length+1][str1.length+1];
+
+    for (int i = 1; i < str2.length + 1; i++) {
+      for (int j = 1; j < str1.length + 1; j++) {
+        if(str1[j-1] == str2[i-1]) {
+          lcs[i][j] = lcs[i-1][j-1]+1;
+        } else {
+          lcs[i][j] = Math.max(lcs[i-1][j],lcs[i][j-1]);
+
+        }
+      }
+    }
+
+    System.out.println(lcs[str2.length][str1.length]);
+  }
+
+}


### PR DESCRIPTION
분류 : DP
출처 : https://www.acmicpc.net/problem/9251

---
2차원 배열을 활용해 부분 수열의 최대 길이 계산
1. 문자가 같으면 왼쪽 대각선 +1
2. 다르면 왼쪽과 위쪽의 값 중 큰 값

풀이 과정
- 최장 부분 수열 문제를 풀었떤 방법에서 문자열이 2개이므로 2차원 배열 적용
- 직접 예제 케이스 구현
- 문자열이 같을때 조건 수정