### PR TITLE
[백준 12851] 숨바꼭질2

### DIFF
--- a/BOJ/boj_12851.cpp
+++ b/BOJ/boj_12851.cpp
@@ -1,0 +1,63 @@
+/*
+[백준 12851] 숨바꼭질 2
+	출처 : https://www.acmicpc.net/problem/12851
+*/
+
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <set>
+
+struct node {
+	int cost;
+	int pos;
+};
+
+std::pair<int, int> BFS(const int start, const int dest) {
+
+	auto comp = [](const node& a, const node& b) {		return a.cost > b.cost; 	};
+
+	int isVisited[100001] = { 0, };
+
+	std::priority_queue<node, std::vector<node>, decltype(comp)> queue(comp);
+	queue.push({ 0,start });
+
+	int minCost = 2147483647;
+	int answer = 0;
+
+	while (!queue.empty()) {
+		auto now = queue.top();
+		queue.pop();
+
+		isVisited[now.pos] = true;
+
+		if (minCost < now.cost)
+			break;
+
+		if (now.pos == dest) {
+			minCost = now.cost;
+			answer++;
+			continue;
+		}
+
+		if ((now.pos-1) >= 0 && !isVisited[now.pos-1])
+			queue.push({ now.cost + 1,now.pos - 1 });
+		if ((now.pos + 1) <= 100000 && !isVisited[now.pos + 1])
+			queue.push({ now.cost + 1,now.pos + 1 });
+		if ((now.pos * 2) <= 100000 && !isVisited[now.pos * 2])
+			queue.push({ now.cost + 1,now.pos * 2 });
+	}
+	return { minCost,answer };
+}
+
+int main() {
+	std::cin.tie(0);
+	std::ios::sync_with_stdio(false);
+
+	int start, dest;
+	std::cin >> start >> dest;
+
+	std::pair<int, int> answer = BFS(start, dest);
+	std::cout << answer.first << '\n' << answer.second;
+	return 0;
+}


### PR DESCRIPTION
BFS를 활용한 문제.

방문 위치 체크하지 않으면 메모리 초과
Set자료구조를 사용했을 때 시간 초과. 메모리 512mb 준 이유가 있음.

지역변수 초기화는 쓰레기 값이 들어갈 수 있음을 유의하자.